### PR TITLE
Fix scalafmt config

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,0 +1,22 @@
+name: Scala CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+    - uses: coursier/cache-action@v6
+    - name: Run scalafmt check
+      run: sbt scalafmtCheckAll
+    - name: Run tests
+      run: sbt test

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,3 @@
+version = 3.5.9
+maxColumn = 100
+runner.dialect = scala212

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Scala Spark Sandbox
+
+This repository contains a minimal Scala codebase for running Apache Spark jobs.
+
+## Requirements
+- Java 8 or higher
+- [sbt](https://www.scala-sbt.org/)
+
+## Usage
+Run the example job locally:
+
+```bash
+sbt "runMain ExampleSparkJob"
+```
+
+Run tests:
+
+```bash
+sbt test
+```
+
+Check code formatting:
+
+```bash
+sbt scalafmtCheckAll
+```

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,10 @@
+name := "spark-sandbox"
+version := "0.1.0"
+scalaVersion := "2.12.18"
+
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-sql" % "3.5.0" % Provided,
+  "org.scalatest" %% "scalatest" % "3.2.17" % Test
+)
+
+scalafmtOnCompile := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")

--- a/src/main/scala/ExampleSparkJob.scala
+++ b/src/main/scala/ExampleSparkJob.scala
@@ -1,0 +1,17 @@
+import org.apache.spark.sql.SparkSession
+
+object ExampleSparkJob {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("ExampleSparkJob")
+      .getOrCreate()
+
+    import spark.implicits._
+
+    val numbers = spark.range(1, 6).toDF("number")
+    val count = numbers.count()
+    println(s"Total count: $count")
+
+    spark.stop()
+  }
+}

--- a/src/test/scala/ExampleSparkJobSpec.scala
+++ b/src/test/scala/ExampleSparkJobSpec.scala
@@ -1,0 +1,7 @@
+import org.scalatest.funsuite.AnyFunSuite
+
+class ExampleSparkJobSpec extends AnyFunSuite {
+  test("basic math works") {
+    assert(1 + 1 == 2)
+  }
+}


### PR DESCRIPTION
## Summary
- add explicit Scala dialect to `.scalafmt.conf` to satisfy scalafmt

## Testing
- `sbt scalafmtAll` *(fails: `sbt: command not found`)*
- `sbt test` *(fails: `sbt: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685dc90bc464832bbcc8e7e75808c37e